### PR TITLE
Fix bad generated contributor-covenant.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ TBD
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/siman-man/shiritori_server. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/siman-man/shiritori_server. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 


### PR DESCRIPTION
There was an error on a gem which created the readme.md with an invalid markdown link to contributor-covenant.org
